### PR TITLE
speech-dispatcher: update to 0.11.5

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -296,7 +296,6 @@ libglib-2.0.so.0:g_source_remove
 libglib-2.0.so.0:g_spawn_sync
 libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
-libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
 libglib-2.0.so.0:g_strcmp0
 libglib-2.0.so.0:g_strdup
@@ -304,16 +303,15 @@ libglib-2.0.so.0:g_strdup_printf
 libglib-2.0.so.0:g_strdup_vprintf
 libglib-2.0.so.0:g_strerror
 libglib-2.0.so.0:g_strfreev
-libglib-2.0.so.0:g_string_append
 libglib-2.0.so.0:g_string_append_len
 libglib-2.0.so.0:g_string_append_printf
 libglib-2.0.so.0:g_string_free
+libglib-2.0.so.0:g_string_free_and_steal
 libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_insert_len
 libglib-2.0.so.0:g_string_new
 libglib-2.0.so.0:g_string_printf
 libglib-2.0.so.0:g_string_sized_new
-libglib-2.0.so.0:g_string_truncate
 libglib-2.0.so.0:g_strjoin
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strsplit

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : speech-dispatcher
-version    : 0.11.4
-release    : 21
+version    : 0.11.5
+release    : 22
 source     :
-    - https://github.com/brailcom/speechd/releases/download/0.11.4/speech-dispatcher-0.11.4.tar.gz : 8c09221bb72d9db5c89cfd7b919771832b86c3a3772d645601696494edf566b9
+    - https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz : 1ce4759ffabbaf1aeb433a5ec0739be0676e9bdfbae9444a7b3be1b2af3ec12b
 homepage   : https://freebsoft.org/speechd
 license    :
     - GPL-2.0-or-later

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -124,6 +124,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bg/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bg/orca.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bg/symbols.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/bgn/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bn/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bn/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/bn/orca.dic</Path>
@@ -280,6 +281,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/ky/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/ky/symbols.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/lb/emojis.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/lij/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/lo/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/lt/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/lt/orca-chars.dic</Path>
@@ -321,6 +323,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/nn/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/nn_NO/symbols.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/no/emojis.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/nso/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/oc/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/oc/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/oc/orca.dic</Path>
@@ -345,6 +348,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/pt_PT/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/pt_PT/symbols.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/qu/emojis.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/quc/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/rm/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/ro/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/ro/orca-chars.dic</Path>
@@ -400,6 +404,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/th/orca.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/ti/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/tk/emojis.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/tn/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/to/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/tr/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/tr/orca-chars.dic</Path>
@@ -444,7 +449,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">speech-dispatcher</Dependency>
+            <Dependency release="22">speech-dispatcher</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/speech-dispatcher/libspeechd.h</Path>
@@ -457,9 +462,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2022-11-05</Date>
-            <Version>0.11.4</Version>
+        <Update release="22">
+            <Date>2023-08-23</Date>
+            <Version>0.11.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Update CLDR to version 43 and symbols from NVDA.
- Fix parsing and emitting space character.
- Reduce espeak buffer size to avoid ssml issues.
- Add --disable-doc.
- Fix spd-conf not being able to set the default module.
- Fix pausing without index.
- [full changelog](https://raw.githubusercontent.com/brailcom/speechd/0.11.5/NEWS)
 
### Test Plan
spd-say -O # to list TTS engines installed
spd-say -L # to list voices and languages available
spd-say "this is not a drill" # to produce voice output with defaults
spd-say -o rhvoice -l uk "це не навчання" # to produce voice output in lang=uk
M-x speechd-speak-read-buffer # to enjoy lazy evening

### Checklist

- [X] Package was built and tested against unstable
